### PR TITLE
Add BUILD_BULLET3_OPENCL option allowing PSP build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,6 +333,7 @@ IF (APPLE)
 ENDIF()
 
 OPTION(BUILD_BULLET3 "Set when you want to build Bullet 3" ON)
+OPTION(BUILD_BULLET3_OPENCL "Set when you want to build Bullet 3 with OpenCL" ON)
 
 # Optional Python configuration
 # Will not probe environment for Python configuration (which can abort the

--- a/src/BulletCollision/BroadphaseCollision/btDispatcher.h
+++ b/src/BulletCollision/BroadphaseCollision/btDispatcher.h
@@ -24,6 +24,7 @@ This is a modified version of the Bullet Continuous Collision Detection and Phys
 #include <set>
 #include <map>
 #include <unordered_map>
+#include <cstdint>
 
 class btCollisionAlgorithm;
 struct btBroadphaseProxy;

--- a/src/BulletCollision/CollisionDispatch/btCollisionObject.cpp
+++ b/src/BulletCollision/CollisionDispatch/btCollisionObject.cpp
@@ -159,7 +159,7 @@ void btCollisionObject::applyLastSafeWorldTransform(const std::map<int, StuckTet
 		// We sacrifice few iterations to move to the safe position only gradually. This significantly reduces the jitter of
 		// jumping between the safe and stuck positions. The unstuck position will be much closer to the real point of contact.
 		btScalar fraction = getLastSafeApplyCounter() / maxApplySteps;
-		fraction = std::min(fraction, 1.0);
+		fraction = std::min((double)fraction, 1.0);
 
 		btTransform dst = getLastSafeWorldTransform();
 		btTransform src = getWorldTransform();

--- a/src/BulletCollision/Gimpact/btGImpactCollisionAlgorithm.h
+++ b/src/BulletCollision/Gimpact/btGImpactCollisionAlgorithm.h
@@ -48,7 +48,9 @@ class btDispatcher;
 #include "btGImpactCollisionAlgorithmEval.h"
 
 #include <vector>
+#ifdef BT_USE_TBB
 #include <tbb/tbb.h>
+#endif
 
 //! Collision Algorithm for GImpact Shapes
 /*!

--- a/src/BulletCollision/Gimpact/btGImpactCollisionAlgorithmEval.h
+++ b/src/BulletCollision/Gimpact/btGImpactCollisionAlgorithmEval.h
@@ -33,7 +33,9 @@ This is a modified version of the Bullet Continuous Collision Detection and Phys
 #include "LinearMath/btTransform.h"
 #include "gim_pair.h"
 
+#ifdef BT_USE_TBB
 #include <tbb/tbb.h>
+#endif
 
 enum class btFindOnlyFirstPairEnum : uint8_t
 {

--- a/src/BulletCollision/Gimpact/btGImpactQuantizedBvh.h
+++ b/src/BulletCollision/Gimpact/btGImpactQuantizedBvh.h
@@ -37,7 +37,9 @@ This is a modified version of the Bullet Continuous Collision Detection and Phys
 #include <atomic>
 #include <map>
 #include <vector>
+#ifdef BT_USE_TBB
 #include <tbb/tbb.h>
+#endif
 
 class GIM_QUANTIZED_BVH_NODE_ARRAY : public btAlignedObjectArray<BT_QUANTIZED_BVH_NODE>
 {
@@ -197,6 +199,9 @@ struct spinlock
 			{
 				return;
 			}
+#if !defined(_M_ARM64) && !defined(__i386__)
+			static const timespec ns = { 0, 1 };
+#endif
 			// Wait for lock to be released without generating cache misses
 			while (lock_.load(std::memory_order_relaxed))
 			{
@@ -204,8 +209,10 @@ struct spinlock
 				// hyper-threads
 #ifdef _M_ARM64
 				__yield();
-#else
+#elif defined(__i386__)
 				_mm_pause();
+#else
+				nanosleep(&ns, NULL);
 #endif
 			}
 		}

--- a/src/BulletSoftBody/btDeformableContactConstraint.cpp
+++ b/src/BulletSoftBody/btDeformableContactConstraint.cpp
@@ -97,9 +97,9 @@ btScalar btDeformableNodeAnchorConstraint::solveConstraint(const btContactSolver
 		// This greatly improves convergence.
 		if (m_previous_residual_velocity_match != -1.0)
 			if (residualSquare > m_previous_residual_velocity_match)
-				m_convergence_based_relaxation_velocity_match = std::max(0.1, m_convergence_based_relaxation_velocity_match * misconvergenceRelaxationFactor);
+				m_convergence_based_relaxation_velocity_match = std::max(0.1, (double)m_convergence_based_relaxation_velocity_match * misconvergenceRelaxationFactor);
 			else
-				m_convergence_based_relaxation_velocity_match = std::min(1.0, m_convergence_based_relaxation_velocity_match * convergenceRelaxationFactor);
+				m_convergence_based_relaxation_velocity_match = std::min(1.0, (double)m_convergence_based_relaxation_velocity_match * convergenceRelaxationFactor);
 		m_previous_residual_velocity_match = residualSquare;
 
 		// dn is the normal component of velocity diffrerence. Approximates the residual. // todo xuchenhan@: this prob needs to be scaled by dt
@@ -255,9 +255,9 @@ btScalar btDeformableNodeAnchorConstraint::solveSplitImpulse(const btContactSolv
 		// This greatly improves convergence.
 		if (m_previous_residual_position_drift != -1.0)
 			if (residualSquare > m_previous_residual_position_drift)
-				m_convergence_based_relaxation_position_drift = std::max(0.1, m_convergence_based_relaxation_position_drift * misconvergenceRelaxationFactor);
+				m_convergence_based_relaxation_position_drift = std::max(0.1, (double)m_convergence_based_relaxation_position_drift * misconvergenceRelaxationFactor);
 			else
-				m_convergence_based_relaxation_position_drift = std::min(1.0, m_convergence_based_relaxation_position_drift * convergenceRelaxationFactor);
+				m_convergence_based_relaxation_position_drift = std::min(1.0, (double)m_convergence_based_relaxation_position_drift * convergenceRelaxationFactor);
 		m_previous_residual_position_drift = residualSquare;
 
 		btVector3 rigid_impulse = (pos_diff * rigid_impulse_fraction * m_convergence_based_relaxation_position_drift) / infoGlobal.m_timeStep;

--- a/src/BulletSoftBody/btDeformableMultiBodyConstraintSolver.cpp
+++ b/src/BulletSoftBody/btDeformableMultiBodyConstraintSolver.cpp
@@ -220,7 +220,7 @@ void btDeformableMultiBodyConstraintSolver::solveGroupCacheFriendlySplitImpulseI
 							auto it = bodyPenetrations.find(origBodyA);
 							if (it != bodyPenetrations.end())
 								existingPen = it->second;
-							bodyPenetrations.insert_or_assign(origBodyA, std::max(existingPen, solveManifold.m_rhsPenetration));
+							bodyPenetrations.insert_or_assign(origBodyA, std::max(existingPen, (double)solveManifold.m_rhsPenetration));
 						}
 						if (origBodyB)
 						{
@@ -228,7 +228,7 @@ void btDeformableMultiBodyConstraintSolver::solveGroupCacheFriendlySplitImpulseI
 							auto it = bodyPenetrations.find(origBodyB);
 							if (it != bodyPenetrations.end())
 								existingPen = it->second;
-							bodyPenetrations.insert_or_assign(origBodyB, std::max(existingPen, solveManifold.m_rhsPenetration));
+							bodyPenetrations.insert_or_assign(origBodyB, std::max(existingPen, (double)solveManifold.m_rhsPenetration));
 						}
 					}
 					// solve the position correction between deformable and rigid/multibody

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,9 @@
 
 IF(BUILD_BULLET3)
-	SUBDIRS(  Bullet3OpenCL Bullet3Serialize/Bullet2FileLoader Bullet3Dynamics Bullet3Collision Bullet3Geometry )
+IF(BUILD_BULLET3_OPENCL)
+	add_subdirectory( Bullet3OpenCL )
+ENDIF(BUILD_BULLET3_OPENCL)
+	SUBDIRS( Bullet3Serialize/Bullet2FileLoader Bullet3Dynamics Bullet3Collision Bullet3Geometry )
 ENDIF(BUILD_BULLET3)
 
 


### PR DESCRIPTION
For PSP compile use:
```sh
psp-cmake .  -DBUILD_EXTRAS=OFF -DBUILD_CPU_DEMOS=OFF -DBUILD_OPENGL3_DEMOS=OFF -DBUILD_BULLET2_DEMOS=OFF  -DBUILD_UNIT_TESTS=OFF -DBUILD_CLSOCKET=OFF -DBUILD_BULLET3_OPENCL=OFF --install-prefix=${PSPDEV}
make install 
```
The following packages need an update to stezkmil too.
- [mills32/M3D-for-PlayStation-Portable](https://github.com/mills32/M3D-for-PlayStation-Portable/pull/6)
- [psp-packages/bullet3](https://github.com/pspdev/psp-packages/pull/293)
